### PR TITLE
Bump Commerce Omnipay to v3 for Craft/Commerce 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 =========
 
+## 2.2.0 - 2024-06-05
+
+### Changed
+- PayPal Payflow for Craft Commerce now requires Craft 3.7.25 or later.
+- PayPal Payflow for Craft Commerce now requires Commerce 3.3 or later.
+- PayPal Payflow for Craft Commerce now requires Commerce Omnipay v3.
+
 ## 2.1.2 - 2023-03-22
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "verbb/commerce-payflow",
-    "description": "PayPal Payflow payment gateway plugin for Craft Commerce 2",
+    "description": "PayPal Payflow payment gateway plugin for Craft Commerce 3",
     "type": "craft-plugin",
-    "version": "2.1.2",
+    "version": "2.2.0",
     "keywords": [
         "craft",
         "cms",
@@ -28,9 +28,9 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.1.5",
-        "craftcms/commerce": "^2.1.0 || ^3.0.0",
-        "craftcms/commerce-omnipay": "^2.0.0",
+        "craftcms/cms": "^3.7.25",
+        "craftcms/commerce": "^3.3",
+        "craftcms/commerce-omnipay": "^3.0.0",
         "verbb/base": "^1.0.2",
         "omnipay/payflow": "^3.0.0"
     },


### PR DESCRIPTION
This came up because of a Guzzle 7 conflict.