### PR TITLE
Fix method call from rules() to defineRules()

### DIFF
--- a/src/models/PayflowPaymentForm.php
+++ b/src/models/PayflowPaymentForm.php
@@ -27,7 +27,7 @@ class PayflowPaymentForm extends CreditCardPaymentForm
     protected function defineRules(): array
     {
         if (empty($this->cardReference)) {
-            return parent::rules();
+            return parent::defineRules();
         }
 
         return [];


### PR DESCRIPTION
In Craft CMS 5, the rules function calls defineRules, which means if we return rules, it will cause an infinite loop.